### PR TITLE
Fix link to course page

### DIFF
--- a/src/components/Courses/CoursesHome.tsx
+++ b/src/components/Courses/CoursesHome.tsx
@@ -46,6 +46,7 @@ const CoursesHome: React.FC<Props> = ({
               course={course}
               image={getYoutubeThumbnail(imageUrl)}
               lectureToPlayNext={firstLecture}
+              showTags
             />
           )
         })}

--- a/src/components/InputWithAddOn.tsx
+++ b/src/components/InputWithAddOn.tsx
@@ -11,7 +11,10 @@ const InputWithAddOn: React.FC<InputWithAddOnProps> = ({
   placeholder,
   ...reset
 }) => (
-  <div className="flex flex-wrap items-stretch w-full mb-4 relative">
+  <div
+    className="flex flex-wrap items-stretch w-full mb-4 relative "
+    style={{ direction: 'ltr' }}
+  >
     <div className="flex -mr-px">
       <span className="flex items-center leading-normal bg-grey-lighter rounded rounded-r-none border border-r-0 border-grey-light px-3 whitespace-no-wrap text-grey-dark text-sm">
         {prefix}

--- a/src/templates/InstructorView.tsx
+++ b/src/templates/InstructorView.tsx
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby'
 import { useTranslation } from 'gatsby-plugin-react-i18next'
 import Layout from '../components/Layout'
 import CourseCard from '../components/Courses/CourseCard'
+import CourseCardUpcoming from '../components/Courses/CourseCardUpcoming'
 import { getYoutubeThumbnail } from '../common/util'
 import { Course } from '../types/api.types'
 
@@ -26,8 +27,12 @@ const InstructorView: React.FC<InstructorViewProps> = ({ data }) => {
       </div>
       <div className="grid md:grid-cols-3 sm:grid-cols-1 gap-4">
         {courses.map(course => {
+          if (course.node.status === 'Upcoming') {
+            return null
+          }
           const { lectures } = course.node
           const { url: imageUrl } = lectures[0] || {}
+
           return (
             <CourseCard
               key={course.node.id}
@@ -56,8 +61,10 @@ export const pageQuery = graphql`
           description
           slug
           level
+          status
           lectures {
             url
+            slug
           }
           language {
             id


### PR DESCRIPTION
- Fix: link to course page from instructor view isn't working

- Make profile user accounts `ltr`

- Fix: instructor page don't show when there are upcoming courses

- Show tags in course card on courses page