### PR TITLE
Fix react-toastify animation on production build

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,7 @@ module.exports = {
         'bg-language-en',
         'bg-language-sw',
       ],
-      keyframes: true,
+      keyframes: false,
     },
   },
   theme: {


### PR DESCRIPTION
The CSS for animation was being purged by purgeCSS. For now, I stopped purging keyframes, but ideally we want to stop purging them only for react-toastify

[NYALA-320](https://nyala.atlassian.net/browse/NYALA-320) 